### PR TITLE
Make optional options really optional

### DIFF
--- a/calendar/experiments/calendar/ext-calendar-utils.jsm
+++ b/calendar/experiments/calendar/ext-calendar-utils.jsm
@@ -171,7 +171,7 @@ function convertItem(item, options, extension) {
     }
   }
 
-  if (options.format) {
+  if (options?.returnFormat) {
     props.formats = { use: null };
     let formats = options.returnFormat;
     if (!Array.isArray(formats)) {

--- a/calendar/experiments/calendar/parent/ext-calendar-items.js
+++ b/calendar/experiments/calendar/parent/ext-calendar-items.js
@@ -38,7 +38,7 @@ this.calendar_items = class extends ExtensionAPI {
             calendar.getItem(id, listener);
             let [item] = await deferred.promise;
 
-            return convertItem(item, options || {}, context.extension);
+            return convertItem(item, options, context.extension);
           },
           create: async function(calendarId, createProperties) {
             let calendar = getResolvedCalendarById(context.extension, calendarId);


### PR DESCRIPTION
The options object is described as optional in the schema but it's not always optional; some other callers don't pass `|| {}`, and I thought it was easier to use `?.` here rather than polluting all of those callers.

Additionally, the wrong property on the object is checked, so I fixed that while I was here.