### PR TITLE
Make updating event start and end time work

### DIFF
--- a/calendar/experiments/calendar/parent/ext-calendar-items.js
+++ b/calendar/experiments/calendar/parent/ext-calendar-items.js
@@ -68,6 +68,11 @@ this.calendar_items = class extends ExtensionAPI {
             if (!oldItem) {
               throw new ExtensionError("Could not find item " + id);
             }
+            if (oldItem instanceof Ci.calIEvent) {
+              updateProperties.type = "event";
+            } else if (oldItem instanceof Ci.calITodo) {
+              updateProperties.type = "todo";
+            }
             let newItem = propsToItem(updateProperties, oldItem?.clone());
             newItem.calendar = calendar.superCalendar;
 


### PR DESCRIPTION
`propsToItem` doesn't know what to do unless it's given the right `type` of properties.