### PR TITLE
Add Calendar Query Items Function

### DIFF
--- a/calendar/experiments/calendar/ext-calendar-utils.jsm
+++ b/calendar/experiments/calendar/ext-calendar-utils.jsm
@@ -12,6 +12,7 @@ var EXPORTED_SYMBOLS = [
   "propsToItem",
   "convertItem",
   "convertAlarm",
+  "createDate",
 ];
 
 var { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
@@ -217,4 +218,19 @@ function convertAlarm(item, alarm) {
     offset: alarm.offset?.icalString,
     related: ALARM_RELATED_MAP[alarm.related],
   };
+}
+
+function createDate(aYear, aMonth, aDay, aHasTime, aHour, aMinute, aSecond, aTimezone) {
+  let date = Cc["@mozilla.org/calendar/datetime;1"].createInstance(Ci.calIDateTime);
+  date.resetTo(
+    aYear,
+    aMonth,
+    aDay,
+    aHour || 0,
+    aMinute || 0,
+    aSecond || 0,
+    aTimezone || cal.dtz.UTC
+  );
+  date.isDate = !aHasTime;
+  return date;
 }

--- a/calendar/experiments/calendar/schema/calendar-items.json
+++ b/calendar/experiments/calendar/schema/calendar-items.json
@@ -144,6 +144,21 @@
           { "type": "string", "name": "calendarId" },
           { "type": "string", "name": "id" }
         ]
+      },
+      {
+        "name": "query",
+        "async": true,
+        "type": "function",
+        "parameters": [
+          {
+            "name": "queryProps",
+            "type": "object",
+            "properties": {
+              "calendarId": {"type": "string"},
+              "type": {"type": "array", "items": {"type": "string"}, "optional": true}
+            }
+          }
+        ]
       }
     ],
     "events": [


### PR DESCRIPTION
This is not a full implementation, just some basic code I wrote for my own add-ons in Thunderbird. (Actually, some of it I found from using `find` in the Thunderbird source. Found some test files with some useful code.)

Exposed API Additions
------------------------------
All the new functions I've added.

- `calendar.items.query`: Returns all tasks matching the query
  - Properties
    - `queryProps`
      - `calendarId`: The calendar to query for tasks on. I believe this was intended to be optional, but for my code it was fine being required.
        - TypeScript type: `string`
      - `type`: The type of items to query for. I'm not sure what types there are to be aware of, and there's probably a lot more.
        - TypeScript type: `("completed" | "classOcurrences)[]`
  - Returns
    - Array Of
      - `calendarId`: The calendar this task or event belongs to.
        - TypeScript type: `string`
      - `categories`: *Not sure.*
      - `completed`: Whether or not this task or event has been completed.
        - TypeScript type: `boolean`
      - `description`: The description of this task or event.
        - TypeScript type: `string`
      - `dueDate`: The date this task or event is due.
        - TypeScript type: `Date`
      - `id`: The id of this task or event.
        - TypeScript type: `string`
      - `location`: The location this task or event takes place at.
        - TypeScript type: `string`
      - `percentComplete`: How complete this task or event is.
        - TypeScript type: `number`
      - `title`: The title of this task or event. 
        - TypeScript type: `string`
      - `type`: Whether this is a task or event.
        - TypeScript type: `"task" | "event"`

Licensing
-------------
I see there is no license on this repository. I do not mind licensing this code under any reasonable license applied to this repository in the future.